### PR TITLE
Add install_pycutest

### DIFF
--- a/install_pycutest
+++ b/install_pycutest
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Usage: bash install_pycutest
+# Requirements: having Python installed via actions/setup-python.
+
+set -e
+set -x
+
+if [[ "$RUNNER_OS" == "Windows" ]]; then
+  echo "PyCUTEst is not available on $RUNNER_OS" 1>&2
+  exit 1
+elif [[ "$RUNNER_OS" == "Linux" ]]; then
+  # Download CUTEst and its dependencies
+  mkdir "$GITHUB_WORKSPACE/cutest"
+  git clone --depth 1 --branch v2.1.24 https://github.com/ralna/ARCHDefs.git "$GITHUB_WORKSPACE/cutest/archdefs"
+  git clone --depth 1 --branch v2.0.6 https://github.com/ralna/SIFDecode.git "$GITHUB_WORKSPACE/cutest/sifdecode"
+  git clone --depth 1 --branch v2.0.17 https://github.com/ralna/CUTEst.git "$GITHUB_WORKSPACE/cutest/cutest"
+  git clone --depth 1 --branch v0.5 https://bitbucket.org/optrove/sif.git "$GITHUB_WORKSPACE/cutest/mastsif"
+
+  # Set the environment variables
+  export ARCHDEFS="$GITHUB_WORKSPACE/cutest/archdefs"
+  export SIFDECODE="$GITHUB_WORKSPACE/cutest/sifdecode"
+  export CUTEST="$GITHUB_WORKSPACE/cutest/cutest"
+  export MASTSIF="$GITHUB_WORKSPACE/cutest/mastsif"
+  export MYARCH=pc64.lnx.gfo
+  {
+    echo "ARCHDEFS=$ARCHDEFS"
+    echo "SIFDECODE=$SIFDECODE"
+    echo "CUTEST=$CUTEST"
+    echo "MASTSIF=$MASTSIF"
+    echo "MYARCH=$MYARCH"
+  } >> "$GITHUB_ENV"
+
+  # Build and install CUTEst
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/jfowkes/pycutest/master/.install_cutest.sh)"
+elif [[ "$RUNNER_OS" == "macOS" ]]; then
+  # Install gfortran
+  sudo ln -fs /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
+  sudo ln -fs /usr/local/Cellar/gcc@12/*/lib/gcc/12/*.dylib /usr/local/lib/
+
+  # Install CUTEst
+  brew tap optimizers/cutest
+  brew install cutest --without-single
+  brew install mastsif
+
+  # Set the environment variables
+  for f in "archdefs" "sifdecode" "cutest" "mastsif"; do
+    while IFS= read -r line; do
+      echo "${line#export }" >> "$GITHUB_ENV"
+    done <<< "$(cat "$(brew --prefix $f)/$f.bashrc")"
+  done
+fi
+
+# Install PyCUTEst
+echo "PYCUTEST_CACHE=$GITHUB_WORKSPACE" >> "$GITHUB_ENV"
+python -m pip install --progress-bar=off pycutest
+


### PR DESCRIPTION
The new script `install_pycutest` installs PyCUTEst on Linux and macOS. Its only requirement is to have Python installed on the runner.

Typical usage:

```yml
name: install-pycutest

on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
  workflow_dispatch:

jobs:
  run:
    name: Install PyCUTEst for Python ${{ matrix.python-version }} on ${{ matrix.os }}
    runs-on: ${{ matrix.os }}

    strategy:
      fail-fast: false
      matrix:
        os: [ubuntu-latest, macos-latest]
        python-version: ['3.8', '3.9', '3.10', '3.11']

    steps:
      - name: Checkout repository
        uses: actions/checkout@v4

      - name: Setup Python
        uses: actions/setup-python@v4
        with:
          python-version: ${{ matrix.python-version }}

      - name: Install PyCUTEst
        run: bash install_pycutest
```